### PR TITLE
Fix exception in test environment

### DIFF
--- a/components/ManyToManyRelation.php
+++ b/components/ManyToManyRelation.php
@@ -155,7 +155,7 @@ class ManyToManyRelation extends Object
 
     public function fill()
     {
-        if (!$this->fillingRoute) {
+        if (!$this->fillingRoute || !Yii::$app->controller) {
             return;
         }
 


### PR DESCRIPTION
Yii::$app->controller is null in testing environment,
so the "Trying to get property of non-object" exception was thrown on line 162.